### PR TITLE
adds default for mgmt url and uses method in all mgmt calls

### DIFF
--- a/lecli/_version.py
+++ b/lecli/_version.py
@@ -1,4 +1,4 @@
 """
 Version module. We should change the version here when we need to.
 """
-__version__ = '0.7.4'
+__version__ = '0.7.5'

--- a/lecli/api_utils.py
+++ b/lecli/api_utils.py
@@ -304,8 +304,8 @@ def get_management_url():
             return url
         else:
             print_config_error_and_exit(URL_SECTION, 'Log Management URL(%s)' % config_key)
-    except ConfigParser.NoOptionError:
-        print_config_error_and_exit(URL_SECTION, 'Log Management URL(%s)' % config_key)
+    except (ConfigParser.NoOptionError, ConfigParser.NoSectionError):
+        return 'https://rest.logentries.com/management'
 
 
 def pretty_print_string_as_json(text):

--- a/lecli/log/api.py
+++ b/lecli/log/api.py
@@ -7,6 +7,7 @@ import requests
 from lecli import api_utils
 from lecli import response_utils
 
+
 def _url():
     """
     Get rest query url of log resource id

--- a/lecli/team/api.py
+++ b/lecli/team/api.py
@@ -13,8 +13,8 @@ def _url():
     """
     Get rest query url of account resource id.
     """
-    return 'https://rest.logentries.com/management/accounts/%s/teams' % \
-           api_utils.get_account_resource_id()
+    return '%s/accounts/%s/teams' % \
+           (api_utils.get_management_url(), api_utils.get_account_resource_id())
 
 
 def print_teams(response):

--- a/lecli/user/api.py
+++ b/lecli/user/api.py
@@ -16,11 +16,11 @@ def _url(endpoint):
     Get rest query url of account resource id.
     """
     if endpoint == 'owner':
-        return 'https://rest.logentries.com/management/accounts/%s/owners' % \
-               api_utils.get_account_resource_id()
+        return '%s/accounts/%s/owners' % \
+               (api_utils.get_management_url(), api_utils.get_account_resource_id())
     elif endpoint == 'user':
-        return 'https://rest.logentries.com/management/accounts/%s/users' % \
-               api_utils.get_account_resource_id()
+        return '%s/accounts/%s/users' % \
+               (api_utils.get_management_url(), api_utils.get_account_resource_id())
 
 
 def handle_userlist_response(response):

--- a/tests/test_apiutils.py
+++ b/tests/test_apiutils.py
@@ -229,6 +229,12 @@ def test_generate_management_url(mocked_management_url):
     assert "https://rest.logentries.com/management" in result
 
 
+def test_default_management_url():
+    result = api_utils.get_management_url()
+
+    assert "https://rest.logentries.com/management" in result
+
+
 def test_combine_objects():
     left = { "log": {
                 "id": "21dd21e7-708a-4bc4-bf45-ffbc78190ecd",


### PR DESCRIPTION
Use the get_management_url method so users will be able to set own url in config for all mgmt calls