### PR TITLE
LOG-8728 running saved query support on query commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The event and query functionality of the CLI supports a number of different ways
 The 'get recentevents' command allows you to retrieve the most recent log events that have been sent to Logentries.
 The logs to retrieve events from can be specified in a few ways. The Log IDs can be passed directly as a space separated list of log Ids, or you can take advantage of log groups and log nicknames. Log Ids can be obtained from the settings page or log set page of a log in the Logentries UI (https://logentries.com). Log nicknames can be passed using the '--lognick' '-n' arguments, log groups can be passed using the '--loggroup' '-g' arguments. For more information in setting up log nicknames and log groups, see the 'Log Nicknames and Groups' section below.
 By default the 'get recentevents' command will return events for the last 20 minutes. The command also takes an optional time argument that allows you to specify how far back in time you wish to get events from; this is passed using '--last' or '-l' argument.
-It is also possible to provide '-r' (--relative_range) to use relative time range functionality of the Logentries REST API. Check [supported patterns](#supported-relative-time-patterns).
+It is also possible to provide '-r' (--relative-range) to use relative time range functionality of the Logentries REST API. Check [supported patterns](#supported-relative-time-patterns).
 
 Example usage: 
 ```
@@ -88,7 +88,7 @@ lecli get recentevents -g myloggroup -r 'last 1 week'
 The 'get events' command allows for the retrieval of log events within defined time ranges. As with 'get recentevents', logs can be passed to the 'get events' command as a space separated list of log Ids, or you can take advantage of log groups and log nicknames.
 The 'get events' command accepts time ranges in ISO-8601 human readable time format (YYYY-MM-DD HH:MM:SS); time ranges in this format can be passed using the '--datefrom' and '--dateto' arguments. Note, all time values are in UTC timezone. 
 The command also accepts epoch time with second granularity. Epoch format time parameters can be passed using the '--timefrom' '-f' and '--timeto' '-t' arguments. 
-It is also possible to provide '-r' (--relative_range) to use relative time range functionality of the Logentries REST API. Check [supported patterns](#supported-relative-time-patterns).
+It is also possible to provide '-r' (--relative-range) to use relative time range functionality of the Logentries REST API. Check [supported patterns](#supported-relative-time-patterns).
 
 Example usage: 
 ```
@@ -104,7 +104,7 @@ lecli get events --lognick mynicknamedlog -r 'last 3 weeks'
 The 'query' command allows you to run LEQL queries on logs from the command line. Logs can be passed to the 'query' command using a space separated list of log Ids, log groups or log nicknames.
 As with the 'events' command, 'query' accepts time ranges in ISO-8601 human readable time format (YYYY-MM-DD HH:MM:SS); time ranges in this format can be passed using the '--datefrom' and '--dateto' arguments.
 It also accepts epoch time with second granularity. Epoch format time parameters can be passed using the '--timefrom' '-f' and '--timeto' '-t' arguments.
-It is also possible to provide '-r' (--relative_range) to use relative time range functionality of the Logentries REST API. Check [supported patterns](#supported-relative-time-patterns).
+It is also possible to provide '-r' (--relative-range) to use relative time range functionality of the Logentries REST API. Check [supported patterns](#supported-relative-time-patterns).
 
 Any LEQL query type that can be used in the advanced mode in the Logentries UI can also be used with the 'query' command. The LEQL query is passed as a string using the '--leql' '-l' argument. For detailed information on using LEQL see https://logentries.com/doc/search/
 A query can return three types of results. For searches just using a where() and without any calculate or groupby functions then the CLI will print the list of matching log events. Other queries will return either statistical or timeseries data, the CLI willretty print both of these.
@@ -147,6 +147,20 @@ Example usage:
     lecli tail events 12345678-aaaa-bbbb-1234-1234cb123456 --loggroup myloggroup
     lecli tail events 12345678-aaaa-bbbb-1234-1234cb123456 --lognick mylognick
 
+####Running Saved Queries
+Logentries REST API supports running saved queries with its configurated parameters. Events, recent events, query and live tail commands support running saved queries directly from lecli. If your saved query has the log and time range information, no other information need to be supplied to the command. If any these information are not part of the saved query, they must be supplied in the command as well.
+In case a redundant parameter has been supplied(log keys, time range or start and end times), REST will return an error response with a message indicating the redundant parameter and lecli will show this information on terminal.
+
+Example usage:
+First get the saved query id to run with `get savedqueries` command, then use this id in below command formats:
+
+    lecli tail events --saved-query 12345678-aaaa-bbbb-1234-1234cb123456
+    lecli tail events --saved-query 12345678-aaaa-bbbb-1234-1234cb123456 -r 'last 10 min' // if there is no time range information in saved query
+    lecli tail events --saved-query 12345678-aaaa-bbbb-1234-1234cb123456 -f 1481558514334 -t 1481562814000 // if there is no time range information in saved query
+    lecli tail events LOG_KEY_UUID1 LOG_KEY_UUID2... --saved-query SAVED_QUERY_UUID // if there is no log information in saved query
+    "tail events" command can be replaced with "query", "get events", "get recentevents" as they all support saved queries in the same options format.
+
+    
 
 **Log Nicknames, Log Groups, and Query Nicknames**
 --------------------------------------------------

--- a/lecli/query/commands.py
+++ b/lecli/query/commands.py
@@ -1,9 +1,10 @@
+# pylint: disable=too-many-arguments
 """
 Module for query commands
 """
+import time
 import click
 
-from lecli import api_utils
 from lecli.query import api
 
 
@@ -26,30 +27,19 @@ from lecli.query import api
               help='Date/Time to query from (ISO-8601 datetime)')
 @click.option('--dateto',
               help='Date/Time to query to (ISO-8601 datetime)')
-@click.option('-r', '--relative_range',
+@click.option('-r', '--relative-range',
               help='Relative range to query until now (Examples: today, yesterday, last 10 min, '
                    'last 6 weeks')
+@click.option('-s', '--saved-query', help='Saved query UUID to run.', type=click.UUID)
 def query(logkeys, lognick, loggroup, leql, querynick, timefrom, timeto, datefrom, dateto,
-          relative_range):
+          relative_range, saved_query):
     """Query logs using LEQL"""
+    success = api.query(log_keys=logkeys, query_string=leql, date_from=datefrom, date_to=dateto,
+                        time_from=timefrom, time_to=timeto, saved_query_id=saved_query,
+                        relative_time_range=relative_range, querynick=querynick, lognick=lognick,
+                        loggroup=loggroup)
 
-    if lognick:
-        logkeys = api_utils.get_named_logkey(lognick)
-    elif loggroup:
-        logkeys = api_utils.get_named_logkey_group(loggroup)
-
-    if all([leql, querynick]):
-        click.echo("Cannot define a LEQL query and query nickname in the same query request")
-    elif querynick:
-        leql = api_utils.get_named_query(querynick)
-
-    if all([logkeys, leql, timefrom, timeto]):
-        api.post_query(logkeys, leql, time_from=timefrom, time_to=timeto)
-    elif all([logkeys, leql, datefrom, dateto]):
-        api.post_query(logkeys, leql, date_from=datefrom, date_to=dateto)
-    elif all([logkeys, relative_range]):
-        api.post_query(logkeys, leql, time_range=relative_range)
-    else:
+    if not success:
         click.echo("Example usage: lecli query 12345678-aaaa-bbbb-1234-1234cb123456 -q "
                    "'where(method=GET) calculate(count)' -f 1465370400 -t 1465370500")
         click.echo("Example usage: lecli query 12345678-aaaa-bbbb-1234-1234cb123456 -q "
@@ -81,24 +71,18 @@ def query(logkeys, lognick, loggroup, leql, querynick, timefrom, timeto, datefro
               help='Date/Time to get events from (ISO-8601 datetime)')
 @click.option('--dateto', type=click.STRING,
               help='Date/Time to get events to (ISO-8601 datetime)')
-@click.option('-r', '--relative_range', type=click.STRING,
+@click.option('-r', '--relative-range', type=click.STRING,
               help='Relative range to query until now (Examples: today, yesterday, '
                    'last x timeunit: last 2 hours, last 6 weeks etc.')
-def get_events(logkeys, lognick, loggroup, timefrom, timeto, datefrom, dateto, relative_range):
+@click.option('-s', '--saved-query', help='Saved query UUID to run.', type=click.UUID)
+def get_events(logkeys, lognick, loggroup, timefrom, timeto, datefrom, dateto, relative_range,
+               saved_query):
     """Get log events"""
-
-    if lognick:
-        logkeys = api_utils.get_named_logkey(lognick)
-    elif loggroup:
-        logkeys = api_utils.get_named_logkey_group(loggroup)
-
-    if all([logkeys, timefrom, timeto]):
-        api.get_events(logkeys, time_from=timefrom, time_to=timeto)
-    elif all([logkeys, datefrom, dateto]):
-        api.get_events(logkeys, date_from=datefrom, date_to=dateto)
-    elif all([logkeys, relative_range]):
-        api.get_events(logkeys, time_range=relative_range)
-    else:
+    success = api.query(log_keys=logkeys, time_from=timefrom, query_string=api.ALL_EVENTS_QUERY,
+                        time_to=timeto, date_from=datefrom, date_to=dateto, loggroup=loggroup,
+                        relative_time_range=relative_range, lognick=lognick,
+                        saved_query_id=saved_query)
+    if not success:
         click.echo("Example usage: lecli get events 12345678-aaaa-bbbb-1234-1234cb123456 "
                    "-f 1465370400 -t 1465370500")
         click.echo("Example usage: lecli get events 12345678-aaaa-bbbb-1234-1234cb123456 "
@@ -121,22 +105,21 @@ def get_events(logkeys, lognick, loggroup, timefrom, timeto, datefrom, dateto, r
 @click.option('-l', '--last', type=click.INT, default=1200,
               help='Time window from now to now-X in seconds over which events will be returned '
                    '(Defaults to 20 mins)')
-@click.option('-r', '--relative_range', type=click.STRING,
+@click.option('-r', '--relative-range', type=click.STRING,
               help='Relative range to query until now (Examples: today, yesterday, '
                    'last x timeunit: last 2 hours, last 6 weeks etc.')
-def get_recent_events(logkeys, lognick, loggroup, last, relative_range):
+@click.option('-s', '--saved-query', help='Saved query to run', type=click.UUID)
+def get_recent_events(logkeys, lognick, loggroup, last, relative_range, saved_query):
     """Get recent log events"""
+    start_time = now = None
+    if not relative_range:
+        now = time.time()
+        start_time = now - last
 
-    if lognick:
-        logkeys = api_utils.get_named_logkey(lognick)
-    elif loggroup:
-        logkeys = api_utils.get_named_logkey_group(loggroup)
-
-    if all([logkeys, relative_range]):
-        api.get_recent_events(logkeys, time_range=relative_range)
-    elif all([logkeys, last]):
-        api.get_recent_events(logkeys, last_x_seconds=last)
-    else:
+    success = api.query(log_keys=logkeys, query_string=api.ALL_EVENTS_QUERY,
+                        time_from=start_time, time_to=now, relative_time_range=relative_range,
+                        lognick=lognick, loggroup=loggroup, saved_query_id=saved_query)
+    if not success:
         click.echo(
             'Example usage: lecli get recentevents 12345678-aaaa-bbbb-1234-1234cb123456 -l 200')
         click.echo('Example usage: lecli get recentevents -n mynicknamedlog -l 200')
@@ -153,16 +136,12 @@ def get_recent_events(logkeys, lognick, loggroup, last, relative_range):
               help='Name of log group defined in config file')
 @click.option('-l', '--leql', type=click.STRING, default=None,
               help='LEQL query to filter')
-@click.option('-i', '--poll_interval', type=click.FLOAT, default=1.0,
+@click.option('-i', '--poll-interval', type=click.FLOAT, default=1.0,
               help='Request interval of live tail in seconds, default is 1.0 second.')
-def tail_events(logkeys, lognick, loggroup, leql, poll_interval):
+@click.option('-s', '--saved-query', type=click.UUID, help='Saved query id to tail.')
+def tail_events(logkeys, lognick, loggroup, leql, poll_interval, saved_query):
     """Tail events of given logkey(s) with provided options"""
-    if lognick:
-        logkeys = api_utils.get_named_logkey(lognick)
-    elif loggroup:
-        logkeys = api_utils.get_named_logkey_group(loggroup)
+    success = api.tail_logs(logkeys, leql, poll_interval, lognick, loggroup, saved_query)
 
-    if len(logkeys) > 0:
-        api.tail_logs(logkeys, leql, poll_interval)
-    else:
+    if not success:
         click.echo("Example usage: lecli tail events 12345678-aaaa-bbbb-1234-1234cb123456")

--- a/lecli/response_utils.py
+++ b/lecli/response_utils.py
@@ -17,7 +17,13 @@ def response_error(response):
     try:
         response.raise_for_status()
     except requests.exceptions.HTTPError as error:
-        print "Request Error:", error.message
+        sys.stderr.write("\nRequest Error:\t %s" % error.message)
+        try:
+            sys.stderr.write("\nError code:\t %s" % response.json()['errorCode'])
+            sys.stderr.write("\nError message:\t %s " % response.json()['message'])
+        except (ValueError, KeyError):
+            pass
+
         if response.status_code == 500:
             sys.stderr.write('Your account may have no owner assigned. '
                              'Please visit www.logentries.com for information on '

--- a/lecli/saved_query/commands.py
+++ b/lecli/saved_query/commands.py
@@ -24,7 +24,7 @@ def get_saved_query(query_id):
 @click.argument('statement', type=click.STRING)
 @click.option('-f', '--timefrom', help='Time to query from (unix epoch)', type=int)
 @click.option('-t', '--timeto', help='Time to query to (unix epoch)', type=int)
-@click.option('-r', '--relative_range', help='Relative time range (ex: last x :timeunit)',
+@click.option('-r', '--relative-range', help='Relative time range (ex: last x :timeunit)',
               type=click.STRING)
 @click.option('-l', '--logs', help='Logs(colon delimited if multiple)', type=click.STRING)
 def create_saved_query(name, statement, timefrom, timeto, relative_range, logs):
@@ -38,7 +38,7 @@ def create_saved_query(name, statement, timefrom, timeto, relative_range, logs):
 @click.option('-s', '--statement', help='LEQL statement', type=click.STRING)
 @click.option('-f', '--timefrom', help='Time to query from (unix epoch)', type=int)
 @click.option('-t', '--timeto', help='Time to query to (unix epoch)', type=int)
-@click.option('-r', '--relative_range', help='Relative time range (ex: last x :timeunit)',
+@click.option('-r', '--relative-range', help='Relative time range (ex: last x :timeunit)',
               type=click.STRING)
 @click.option('-l', '--logs', help='Logs(colon delimited if multiple)', type=click.STRING)
 def update_saved_query(query_id, name, statement, timefrom, timeto, relative_range, logs):

--- a/tests/test_lecli.py
+++ b/tests/test_lecli.py
@@ -47,28 +47,52 @@ def test_userlist(mocked_list_users):
     mocked_list_users.assert_called_once_with()
 
 
-@patch('lecli.query.api.get_recent_events')
-def test_recentevents(mocked_recent_events):
+@patch('lecli.query.api.query')
+def test_recentevents(mocked_query):
     runner = CliRunner()
     runner.invoke(cli.query_commands.get_recent_events, ['test'])
 
-    assert mocked_recent_events.called
+    assert mocked_query.called
 
 
-@patch('lecli.query.api.get_recent_events')
-def test_recentevents_with_relative_range(mocked_recent_events):
+@patch('lecli.query.api.query')
+def test_recentevents_with_saved_query(mocked_query):
+    runner = CliRunner()
+    runner.invoke(cli.query_commands.get_recent_events, ['test', '-s', str(uuid.uuid4())])
+
+    assert mocked_query.called
+
+
+@patch('lecli.query.api.query')
+def test_recentevents_with_relative_range(mocked_query):
     runner = CliRunner()
     runner.invoke(cli.query_commands.get_recent_events, ['test', '-r', 'last 3 min'])
 
-    assert mocked_recent_events.called
+    assert mocked_query.called
 
 
-@patch('lecli.query.api.get_events')
-def test_events(mocked_get_events):
+@patch('lecli.query.api.query')
+def test_events(mocked_query):
     runner = CliRunner()
     runner.invoke(cli.query_commands.get_events, ['', '-f', int(time.time()), '-t', int(time.time())])
 
-    assert mocked_get_events.called
+    assert mocked_query.called
+
+
+@patch('lecli.query.api.query')
+def test_events_with_relative_range(mocked_query):
+    runner = CliRunner()
+    runner.invoke(cli.query_commands.get_events, ['', '-r', 'last 3 min'])
+
+    assert mocked_query.called
+
+
+@patch('lecli.query.api.query')
+def test_events_with_saved_query(mocked_query):
+    runner = CliRunner()
+    runner.invoke(cli.query_commands.get_events, ['123123123', '-s', str(uuid.uuid4())])
+
+    assert mocked_query.called
 
 
 @patch('lecli.query.api.tail_logs')
@@ -79,15 +103,15 @@ def test_live_tail(mocked_tail_logs):
     assert mocked_tail_logs.called
 
 
-@patch('lecli.query.api.get_events')
-def test_events_with_relative_range(mocked_get_events):
+@patch('lecli.query.api.tail_logs')
+def test_live_tail_with_saved_query(mocked_tail_logs):
     runner = CliRunner()
-    runner.invoke(cli.query_commands.get_events, ['', '-r', 'last 3 min'])
+    runner.invoke(cli.query_commands.tail_events, ['', '-s', str(uuid.uuid4())])
 
-    assert mocked_get_events.called
+    assert mocked_tail_logs.called
 
 
-@patch('lecli.query.api.post_query')
+@patch('lecli.query.api.query')
 def test_query(mocked_post_query):
     runner = CliRunner()
     runner.invoke(cli.query_commands.query, [str(uuid.uuid4()), '-l', 'where(event)', '-f',
@@ -95,10 +119,18 @@ def test_query(mocked_post_query):
     assert mocked_post_query.called
 
 
-@patch('lecli.query.api.post_query')
+@patch('lecli.query.api.query')
 def test_query_with_relative_range(mocked_post_query):
     runner = CliRunner()
     runner.invoke(cli.query_commands.query, ['', '-l', '', '-r', 'last 3 min'])
+
+    assert mocked_post_query.called
+
+
+@patch('lecli.query.api.query')
+def test_query_with_saved_query(mocked_post_query):
+    runner = CliRunner()
+    runner.invoke(cli.query_commands.query, ['', '-s', str(uuid.uuid4())])
 
     assert mocked_post_query.called
 


### PR DESCRIPTION
This PR adds saved query support to various query related commands such as **get events,** **get recentevents**, **query**, **tail events**.  This also extends validation of query commands. 


There is some commit noise as I had to do some refactoring after bumping onto some code duplication on query module. Also let me know if you think there's a better way of refactoring this part of code.