### PR TITLE
LOG-9749 cli introduces a new concept of log groups and nick names

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The event and query functionality of the CLI supports a number of different ways
 ####Recent Events
 
 The 'get recentevents' command allows you to retrieve the most recent log events that have been sent to Logentries.
-The logs to retrieve events from can be specified in a few ways. The Log IDs can be passed directly as a space separated list of log Ids, or you can take advantage of log sets and CLI Favorites. Log Ids can be obtained from the settings page or logsets page of a log in the Logentries UI (https://logentries.com). CLI favorites can be passed using the '--favorites' '-c' arguments, logset ID can be passed using the '--logset' '-g' arguments. For more information in setting up CLI Favorites and using log sets, see the 'CLI Favorites and Log Sets' section below.
+The logs to retrieve events from can be specified in a few ways. The Log IDs can be passed directly as a space separated list of log Ids, or you can take advantage of log sets and CLI Favorites. Log Ids can be obtained from the settings page or logsets page of a log in the Logentries UI (https://logentries.com). CLI favorites can be passed using the '--favorites' '-c' arguments, logset ID can be passed using the '--logset' '-g' arguments. For more information in setting up CLI Favorites and using log sets, see the 'Cli Favorites and Log Sets' section below.
 By default the 'get recentevents' command will return events for the last 20 minutes. The command also takes an optional time argument that allows you to specify how far back in time you wish to get events from; this is passed using '--last' or '-l' argument.
 It is also possible to provide '-r' (--relative-range) to use relative time range functionality of the Logentries REST API. Check [supported patterns](#supported-relative-time-patterns).
 
@@ -156,12 +156,12 @@ First get the saved query id to run with `get savedqueries` command, then use th
 
 **CLI favorites and Log Sets**
 --------------------------------------------------
-The CLI supports the use in query commands of CLI Favorites (log alias) via the configuration file and log sets from the Logentries account. This makes searching well known or large lists of logs much simpler as you do not need to pass in lists of log Ids.
+The CLI supports command line favorites (CLI Favorites) for query commands as well as log sets from the Logentries account. This makes searching well known or large lists of logs much simpler as you do not need to pass in lists of log Ids.
 
 #### CLI Favorites
-CLI Favorites allow an alias for a single log or a list of log Ids to be configured, this is done in the CLI_Favorites section of the configuration file. 
+CLI Favorites allow an alias for a single log or a list of log Ids to be configured, this is done in the 'Cli_Favorites' section of the configuration file. 
 ```
-[CLI_Favorites]
+[Cli_Favorites]
 favlog =    12345678-aaaa-bbbb-1234-1234cb123456
 favlist =   12345678-aaaa-bbbb-1234-1234cb123456
             12345678-aaaa-bbbb-1234-1234cb123457

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The event and query functionality of the CLI supports a number of different ways
 ####Recent Events
 
 The 'get recentevents' command allows you to retrieve the most recent log events that have been sent to Logentries.
-The logs to retrieve events from can be specified in a few ways. The Log IDs can be passed directly as a space separated list of log Ids, or you can take advantage of log groups and log nicknames. Log Ids can be obtained from the settings page or log set page of a log in the Logentries UI (https://logentries.com). Log nicknames can be passed using the '--lognick' '-n' arguments, log groups can be passed using the '--loggroup' '-g' arguments. For more information in setting up log nicknames and log groups, see the 'Log Nicknames and Groups' section below.
+The logs to retrieve events from can be specified in a few ways. The Log IDs can be passed directly as a space separated list of log Ids, or you can take advantage of log sets and CLI Favorites. Log Ids can be obtained from the settings page or logsets page of a log in the Logentries UI (https://logentries.com). CLI favorites can be passed using the '--favorites' '-c' arguments, logset ID can be passed using the '--logset' '-g' arguments. For more information in setting up CLI Favorites and using log sets, see the 'CLI Favorites and Log Sets' section below.
 By default the 'get recentevents' command will return events for the last 20 minutes. The command also takes an optional time argument that allows you to specify how far back in time you wish to get events from; this is passed using '--last' or '-l' argument.
 It is also possible to provide '-r' (--relative-range) to use relative time range functionality of the Logentries REST API. Check [supported patterns](#supported-relative-time-patterns).
 
@@ -79,13 +79,13 @@ Example usage:
 ```
 lecli get recentevents 12345678-aaaa-bbbb-1234-1234cb123456 -l 200
 lecli get recentevents 12345678-aaaa-bbbb-1234-1234cb123456 -r 'last 2 hours'
-lecli get recentevents -n mynicknamedlog -l 200
-lecli get recentevents -g myloggroup -l 200
-lecli get recentevents -g myloggroup -r 'last 1 week'
+lecli get recentevents -c mylogalias -l 200
+lecli get recentevents --logset 12345678-aaaa-bbbb-1234-1234cb123457 -l 200
+lecli get recentevents -g 12345678-aaaa-bbbb-1234-1234cb123457 -r 'last 1 week'
 ```
 
 ####Events
-The 'get events' command allows for the retrieval of log events within defined time ranges. As with 'get recentevents', logs can be passed to the 'get events' command as a space separated list of log Ids, or you can take advantage of log groups and log nicknames.
+The 'get events' command allows for the retrieval of log events within defined time ranges. As with 'get recentevents', logs can be passed to the 'get events' command as a space separated list of log Ids, or you can take advantage of log sets and CLI Favorites.
 The 'get events' command accepts time ranges in ISO-8601 human readable time format (YYYY-MM-DD HH:MM:SS); time ranges in this format can be passed using the '--datefrom' and '--dateto' arguments. Note, all time values are in UTC timezone. 
 The command also accepts epoch time with second granularity. Epoch format time parameters can be passed using the '--timefrom' '-f' and '--timeto' '-t' arguments. 
 It is also possible to provide '-r' (--relative-range) to use relative time range functionality of the Logentries REST API. Check [supported patterns](#supported-relative-time-patterns).
@@ -95,31 +95,24 @@ Example usage:
 lecli get events 12345678-aaaa-bbbb-1234-1234cb123456 -f 1465370400 -t 1465370500
 lecli get events 12345678-aaaa-bbbb-1234-1234cb123456 --datefrom '2016-05-18 11:04:00' --dateto '2016-05-18 11:09:59'
 lecli get events 12345678-aaaa-bbbb-1234-1234cb123456 -r 'yesterday'
-lecli get events --loggroup myloggroup --datefrom '2016-05-18 11:04:00' --dateto '2016-05-18 11:09:59'
-lecli get events --lognick mynicknamedlog --datefrom '2016-05-18 11:04:00' --dateto '2016-05-18 11:09:59'
-lecli get events --lognick mynicknamedlog -r 'last 3 weeks'
+lecli get events --logset 12345678-aaaa-bbbb-1234-1234cb123457 --datefrom '2016-05-18 11:04:00' --dateto '2016-05-18 11:09:59'
+lecli get events --favorites mylogalias --datefrom '2016-05-18 11:04:00' --dateto '2016-05-18 11:09:59'
+lecli get events --favorites mylogalias -r 'last 3 weeks'
 ```
 
 ####Query
-The 'query' command allows you to run LEQL queries on logs from the command line. Logs can be passed to the 'query' command using a space separated list of log Ids, log groups or log nicknames.
+The 'query' command allows you to run LEQL queries on logs from the command line. Logs can be passed to the 'query' command using a space separated list of log Ids, log sets or CLI Favorites.
 As with the 'events' command, 'query' accepts time ranges in ISO-8601 human readable time format (YYYY-MM-DD HH:MM:SS); time ranges in this format can be passed using the '--datefrom' and '--dateto' arguments.
 It also accepts epoch time with second granularity. Epoch format time parameters can be passed using the '--timefrom' '-f' and '--timeto' '-t' arguments.
 It is also possible to provide '-r' (--relative-range) to use relative time range functionality of the Logentries REST API. Check [supported patterns](#supported-relative-time-patterns).
 
 Any LEQL query type that can be used in the advanced mode in the Logentries UI can also be used with the 'query' command. The LEQL query is passed as a string using the '--leql' '-l' argument. For detailed information on using LEQL see https://logentries.com/doc/search/
-A query can return three types of results. For searches just using a where() and without any calculate or groupby functions then the CLI will print the list of matching log events. Other queries will return either statistical or timeseries data, the CLI willretty print both of these.
-
-Similar to log nicknames, query nicknames allow well known queries to be set in the configuration file and easily used as part of a query command. A query shortcut can be used instead of a leql query using the '--querynick' '-q' argument.
+A query can return three types of results. For searches just using a where() and without any calculate or groupby functions then the CLI will print the list of matching log events. Other queries will return either statistical or timeseries data, the CLI will pretty print both of these.
 
 Example usage:
 ```
-lecli query 12345678-aaaa-bbbb-1234-1234cb123456 -q 'where(method=GET) calculate(count)' -f 1465370400 -t 1465370500
-lecli query 12345678-aaaa-bbbb-1234-1234cb123456 -q 'where(method=GET) calculate(count)'  --datefrom '2016-05-18 11:04:00' --dateto '2016-05-18 11:09:59'
-lecli query 12345678-aaaa-bbbb-1234-1234cb123456 -q 'where(method=GET) calculate(count)'  -r 'last 2 days'
-lecli query --loggroup myloggroup --leql 'where(method=GET) calculate(count)' --datefrom '2016-05-18 11:04:00' --dateto '2016-05-18 11:09:59'
-lecli query --lognick mynicknamedlog --leql 'where(method=GET) calculate(count)' --datefrom '2016-05-18 11:04:00' --dateto '2016-05-18 11:09:59'
-lecli query --lognick mynicknamedlog -q testquery --datefrom '2016-05-18 11:04:00' --dateto '2016-05-18 11:09:59'
-lecli query --lognick mynicknamedlog -q testquery -r 'last 15 mins'
+lecli query --logset 12345678-aaaa-bbbb-1234-1234cb123457 --leql 'where(method=GET) calculate(count)' --datefrom '2016-05-18 11:04:00' --dateto '2016-05-18 11:09:59'
+lecli query --favorites mylogalias --leql 'where(method=GET) calculate(count)' --datefrom '2016-05-18 11:04:00' --dateto '2016-05-18 11:09:59'
 ```
 
 ####Supported Relative Time Patterns
@@ -136,16 +129,15 @@ Logentries REST API also supports relative time ranges instead of absolute `star
   - year, years
 
 ####Live Tail
-Logentries REST API supports tailing log events in real time. Lecli makes use of this with `tail events` command. While logkeys(space separated log keys) is a mandatory argument for this command, `--leql`, `--lognick` and `--loggroup` options are supported for this command.
+Logentries REST API supports tailing log events in real time. Lecli makes use of this with `tail events` command. While logkeys(space separated log keys) is a mandatory argument for this command, `--leql`, `--favorites` and `--logset` options are supported for this command.
 Another option is `--poll-interval` or `-i`, which is the request interval to the live tail API. Defaults to 1.0 seconds. As this may affect api key limits, it should be used carefully.
 
 Example usage:
 
     lecli tail events 12345678-aaaa-bbbb-1234-1234cb123456
     lecli tail events 12345678-aaaa-bbbb-1234-1234cb123456 -i 5.0 --leql 'where(event=login)'
-    lecli tail events 12345678-aaaa-bbbb-1234-1234cb123456 -q 'where(event)'
-    lecli tail events 12345678-aaaa-bbbb-1234-1234cb123456 --loggroup myloggroup
-    lecli tail events 12345678-aaaa-bbbb-1234-1234cb123456 --lognick mylognick
+    lecli tail events 12345678-aaaa-bbbb-1234-1234cb123456 --logset 12345678-aaaa-bbbb-1234-1234cb123457
+    lecli tail events 12345678-aaaa-bbbb-1234-1234cb123456 --favorites mylogalias
 
 ####Running Saved Queries
 Logentries REST API supports running saved queries with its configurated parameters. Events, recent events, query and live tail commands support running saved queries directly from lecli. If your saved query has the log and time range information, no other information need to be supplied to the command. If any these information are not part of the saved query, they must be supplied in the command as well.
@@ -162,30 +154,24 @@ First get the saved query id to run with `get savedqueries` command, then use th
 
     
 
-**Log Nicknames, Log Groups, and Query Nicknames**
+**CLI favorites and Log Sets**
 --------------------------------------------------
-The CLI supports the use of log nicknames and log groups via the configuration file. This makes searching well known or large lists of logs much simpler as you do not need to pass in lists of log Ids.
+The CLI supports the use in query commands of CLI Favorites (log alias) via the configuration file and log sets from the Logentries account. This makes searching well known or large lists of logs much simpler as you do not need to pass in lists of log Ids.
 
-####Log Nicknames
-Log nicknames allow an alias for a single log to be configured, this is done in the LogNicknames section of the configuration file. 
+#### CLI Favorites
+CLI Favorites allow an alias for a single log or a list of log Ids to be configured, this is done in the CLI_Favorites section of the configuration file. 
 ```
-[LogNicknames]
-testlog = 12345678-aaaa-bbbb-1234-1234cb123456
-```
-
-####Log Groups
-Log groups allow an alias for a list of log Ids to be created. These can be setup in the LogGroups section of the configuration file. 
-```
-[LogGroups]
-testgroup = 12345678-aaaa-bbbb-1234-1234cb123456
+[CLI_Favorites]
+favlog =    12345678-aaaa-bbbb-1234-1234cb123456
+favlist =   12345678-aaaa-bbbb-1234-1234cb123456
             12345678-aaaa-bbbb-1234-1234cb123457
 ```
 
-####Query Nicknames
-Query nicknames provide an easy way to add aliases for long or frequently run queries. These are setup in the QueryNicknames section of the configuration file.
+#### Log Sets
+The Logset '-g' or '--logset' option allows for a list of log Ids to be used from an existing logset (see below for details on logset management). Where a logset Id is used a request is made on the server to get a list of any log Ids that are present in that logset. That list of log Ids are then used in the command. No information from the logset is retained in the config file.
 ```
-[QueryNicknames]
-testquery = where(logID) groupby(logID) calculate(count) sort(desc) limit(3)
+lecli query --logset 12345678-aaaa-bbbb-1234-1234cb123457 --leql 'calculate(count)' -r 'last 3 days'
+lecli query -g 12345678-aaaa-bbbb-1234-1234cb123457 --leql 'calculate(count)' -r 'last 3 days'
 ```
 
 **User and Account Management**

--- a/lecli/api_utils.py
+++ b/lecli/api_utils.py
@@ -19,6 +19,8 @@ import lecli
 
 AUTH_SECTION = 'Auth'
 URL_SECTION = 'Url'
+LOGGROUPS_SECTION = 'LogGroups'
+CLI_FAVORITES_SECTION = 'CLI_Favorites'
 CONFIG = ConfigParser.ConfigParser()
 CONFIG_FILE_PATH = os.path.join(user_config_dir(lecli.__name__), 'config.ini')
 DEFAULT_API_URL = 'https://rest.logentries.com'
@@ -90,6 +92,25 @@ def load_config():
         print_config_error_and_exit()
     if not CONFIG.has_section(AUTH_SECTION):
         print_config_error_and_exit(section=AUTH_SECTION)
+    if CONFIG.has_section(LOGGROUPS_SECTION):
+        remove_loggroup_section()
+
+
+def remove_loggroup_section():
+    """
+    If config has legacy LogGroup section, take all its items and add
+    them to the CLI_Favorites section - then delete the legacy section.
+    Update the config file with the changes.
+    """
+    existing_groups = CONFIG.items(LOGGROUPS_SECTION)
+    if not CONFIG.has_section(CLI_FAVORITES_SECTION):
+        CONFIG.add_section(CLI_FAVORITES_SECTION)
+    for group in existing_groups:
+        CONFIG.set(CLI_FAVORITES_SECTION, group[0], group[1])
+    CONFIG.remove_section(LOGGROUPS_SECTION)
+    config_file = open(CONFIG_FILE_PATH, 'w')
+    CONFIG.write(config_file)
+    config_file.close()
 
 
 def get_ro_apikey():

--- a/lecli/api_utils.py
+++ b/lecli/api_utils.py
@@ -20,7 +20,7 @@ import lecli
 AUTH_SECTION = 'Auth'
 URL_SECTION = 'Url'
 LOGGROUPS_SECTION = 'LogGroups'
-CLI_FAVORITES_SECTION = 'CLI_Favorites'
+CLI_FAVORITES_SECTION = 'Cli_Favorites'
 CONFIG = ConfigParser.ConfigParser()
 CONFIG_FILE_PATH = os.path.join(user_config_dir(lecli.__name__), 'config.ini')
 DEFAULT_API_URL = 'https://rest.logentries.com'
@@ -64,8 +64,8 @@ def init_config():
         dummy_config.set(AUTH_SECTION, 'rw_api_key', '')
         dummy_config.set(AUTH_SECTION, 'ro_api_key', '')
 
-        dummy_config.add_section('CLI_Favorites')
-        dummy_config.add_section('Url')
+        dummy_config.add_section(CLI_FAVORITES_SECTION)
+        dummy_config.add_section(URL_SECTION)
         dummy_config.set(URL_SECTION, 'api_url', 'https://rest.logentries.com')
 
         dummy_config.write(config_file)
@@ -208,7 +208,7 @@ def get_named_logkey_group(name):
     :param name: name of the log key list
     """
 
-    section = 'CLI_Favorites'
+    section = CLI_FAVORITES_SECTION
     try:
         groups = dict(CONFIG.items(section))
         name = name.lower()

--- a/lecli/api_utils.py
+++ b/lecli/api_utils.py
@@ -93,10 +93,10 @@ def load_config():
     if not CONFIG.has_section(AUTH_SECTION):
         print_config_error_and_exit(section=AUTH_SECTION)
     if CONFIG.has_section(LOGGROUPS_SECTION):
-        remove_loggroup_section()
+        replace_loggroup_section()
 
 
-def remove_loggroup_section():
+def replace_loggroup_section():
     """
     If config has legacy LogGroup section, take all its items and add
     them to the CLI_Favorites section - then delete the legacy section.

--- a/lecli/api_utils.py
+++ b/lecli/api_utils.py
@@ -62,8 +62,7 @@ def init_config():
         dummy_config.set(AUTH_SECTION, 'rw_api_key', '')
         dummy_config.set(AUTH_SECTION, 'ro_api_key', '')
 
-        dummy_config.add_section('LogNicknames')
-        dummy_config.add_section("LogGroups")
+        dummy_config.add_section('CLI_Favorites')
         dummy_config.add_section('Url')
         dummy_config.set(URL_SECTION, 'api_url', 'https://rest.logentries.com')
 
@@ -183,12 +182,12 @@ def get_account_resource_id():
 
 def get_named_logkey_group(name):
     """
-    Get named log-key group from the config file.
+    Get named log-key list from the config file.
 
-    :param name: name of the group
+    :param name: name of the log key list
     """
 
-    section = 'LogGroups'
+    section = 'CLI_Favorites'
     try:
         groups = dict(CONFIG.items(section))
         name = name.lower()
@@ -200,51 +199,6 @@ def get_named_logkey_group(name):
             return logkeys
         else:
             print_config_error_and_exit(section, 'Named Logkey Group(%s)' % name)
-    except ConfigParser.NoSectionError:
-        print_config_error_and_exit(section)
-
-
-def get_named_logkey(name):
-    """
-    Get named log-key from the config file.
-
-    :param name: name of the log key
-    """
-
-    section = 'LogNicknames'
-
-    try:
-        named_logkeys = dict(CONFIG.items(section))
-        name = name.lower()
-        if name in named_logkeys:
-            logkey = (named_logkeys[name],)
-            if not validators.uuid(logkey[0]):
-                print_config_error_and_exit(section, 'Named Logkey(%s)' % name, logkey)
-            else:
-                return logkey
-        else:
-            print_config_error_and_exit(section, 'Named Logkey(%s)' % name)
-    except ConfigParser.NoSectionError:
-        print_config_error_and_exit(section)
-
-
-def get_named_query(name):
-    """
-    Get named query from config file.
-
-    :param name: query nick
-    """
-
-    section = 'QueryNicknames'
-
-    try:
-        named_queries = dict(CONFIG.items(section))
-        name = name.lower()
-        if name in named_queries:
-            query = named_queries[name]
-            return query
-        else:
-            print_config_error_and_exit(section, 'Named Query(%s)' % name)
     except ConfigParser.NoSectionError:
         print_config_error_and_exit(section)
 

--- a/lecli/logset/api.py
+++ b/lecli/logset/api.py
@@ -175,6 +175,31 @@ def extract_log_from_logset(logset, log_id):
         sys.exit(1)
 
 
+def get_log_keys_from_logset(logset_id):
+    """Helper method to get list of log IDs in a logset"""
+    headers = api_utils.generate_headers('ro')
+    log_ids = []
+    try:
+        response = requests.get(_url((logset_id,))[1], headers=headers)
+        if response_utils.response_error(response):
+            sys.stderr.write('Attempt to access logset %s failed\n' % logset_id)
+            sys.exit(1)
+        elif response.status_code == 200:
+            existing_logset = response.json()
+            if 'logs_info' in existing_logset['logset']:
+                for log in existing_logset['logset']['logs_info']:
+                    log_ids.append(log['id'])
+    except requests.exceptions.RequestException as error:
+        sys.stderr.write(error)
+        sys.exit(1)
+
+    if log_ids is not []:
+        return log_ids
+    else:
+        sys.stderr.write("No logs found in logset %s " % logset_id)
+        sys.exit(1)
+
+
 def delete_log(logset_id, log_id):
     """
     Delete a log from the logset

--- a/lecli/query/commands.py
+++ b/lecli/query/commands.py
@@ -11,14 +11,12 @@ from lecli.query import api
 @click.command()
 # nargs (-1) makes sure multiple log keys is supported
 @click.argument('logkeys', type=click.STRING, nargs=-1)
-@click.option('-n', '--lognick', default=None,
-              help='Nickname of log in config file')
-@click.option('-g', '--loggroup', default=None,
-              help='Name of log group defined in config file')
+@click.option('-c', '--favorites', default=None,
+              help='Alias of log in config file')
+@click.option('-g', '--logset', default=None,
+              help='Name of logset to be got from server')
 @click.option('-l', '--leql', default=None,
               help='LEQL query')
-@click.option('-q', '--querynick',
-              help='Query shortcut nickname')
 @click.option('-f', '--timefrom',
               help='Time to query from (unix epoch)', type=int)
 @click.option('-t', '--timeto',
@@ -31,27 +29,21 @@ from lecli.query import api
               help='Relative range to query until now (Examples: today, yesterday, last 10 min, '
                    'last 6 weeks')
 @click.option('-s', '--saved-query', help='Saved query UUID to run.', type=click.UUID)
-def query(logkeys, lognick, loggroup, leql, querynick, timefrom, timeto, datefrom, dateto,
+def query(logkeys, favorites, logset, leql, timefrom, timeto, datefrom, dateto,
           relative_range, saved_query):
     """Query logs using LEQL"""
     success = api.query(log_keys=logkeys, query_string=leql, date_from=datefrom, date_to=dateto,
                         time_from=timefrom, time_to=timeto, saved_query_id=saved_query,
-                        relative_time_range=relative_range, querynick=querynick, lognick=lognick,
-                        loggroup=loggroup)
+                        relative_time_range=relative_range, favorites=favorites, logset=logset)
 
     if not success:
-        click.echo("Example usage: lecli query 12345678-aaaa-bbbb-1234-1234cb123456 -q "
-                   "'where(method=GET) calculate(count)' -f 1465370400 -t 1465370500")
-        click.echo("Example usage: lecli query 12345678-aaaa-bbbb-1234-1234cb123456 -q "
-                   "'where(method=GET) calculate(count)'  "
-                   "--datefrom '2016-05-18 11:04:00' --dateto '2016-05-18 11:09:59' ")
-        click.echo("Example usage: lecli query --loggroup myloggroup --leql "
+        click.echo("Example usage: lecli query --logset mylogset --leql "
                    "'where(method=GET) calculate(count)' "
                    "--datefrom '2016-05-18 11:04:00' --dateto '2016-05-18 11:09:59' ")
-        click.echo("Example usage: lecli query --lognick mynicknamedlog --leql "
+        click.echo("Example usage: lecli query --favorites mylogalias --leql "
                    "'where(method=GET) calculate(count)' "
                    "--datefrom '2016-05-18 11:04:00' --dateto '2016-05-18 11:09:59' ")
-        click.echo("Example usage: lecli query --lognick mynicknamedlog --leql "
+        click.echo("Example usage: lecli query --favorites mylogalias --leql "
                    "'where(method=GET) calculate(count)' "
                    "-r 'last 3 days'")
 
@@ -59,10 +51,10 @@ def query(logkeys, lognick, loggroup, leql, querynick, timefrom, timeto, datefro
 @click.command()
 # nargs (-1) makes sure multiple log keys is supported
 @click.argument('logkeys', type=click.STRING, nargs=-1)
-@click.option('-n', '--lognick', type=click.STRING,
-              help='Nickname of log in config file')
-@click.option('-g', '--loggroup', type=click.STRING,
-              help='Name of log group defined in config file')
+@click.option('-c', '--favorites', type=click.STRING,
+              help='Alias of log in config file')
+@click.option('-g', '--logset', type=click.STRING,
+              help='Name of logset to be got from server')
 @click.option('-f', '--timefrom', type=click.INT,
               help='Time to get events from (unix epoch)')
 @click.option('-t', '--timeto', type=click.INT,
@@ -75,33 +67,33 @@ def query(logkeys, lognick, loggroup, leql, querynick, timefrom, timeto, datefro
               help='Relative range to query until now (Examples: today, yesterday, '
                    'last x timeunit: last 2 hours, last 6 weeks etc.')
 @click.option('-s', '--saved-query', help='Saved query UUID to run.', type=click.UUID)
-def get_events(logkeys, lognick, loggroup, timefrom, timeto, datefrom, dateto, relative_range,
+def get_events(logkeys, favorites, logset, timefrom, timeto, datefrom, dateto, relative_range,
                saved_query):
     """Get log events"""
     success = api.query(log_keys=logkeys, time_from=timefrom, query_string=api.ALL_EVENTS_QUERY,
-                        time_to=timeto, date_from=datefrom, date_to=dateto, loggroup=loggroup,
-                        relative_time_range=relative_range, lognick=lognick,
+                        time_to=timeto, date_from=datefrom, date_to=dateto, logset=logset,
+                        relative_time_range=relative_range, favorites=favorites,
                         saved_query_id=saved_query)
     if not success:
         click.echo("Example usage: lecli get events 12345678-aaaa-bbbb-1234-1234cb123456 "
                    "-f 1465370400 -t 1465370500")
         click.echo("Example usage: lecli get events 12345678-aaaa-bbbb-1234-1234cb123456 "
                    "--datefrom '2016-05-18 11:04:00' --dateto '2016-05-18 11:09:59' ")
-        click.echo("Example usage: lecli get events --loggroup myloggroup "
+        click.echo("Example usage: lecli get events --logset mylogset "
                    "--datefrom '2016-05-18 11:04:00' --dateto '2016-05-18 11:09:59' ")
-        click.echo("Example usage: lecli get events --lognick mynicknamedlog "
+        click.echo("Example usage: lecli get events --favorites mylogalias "
                    "--datefrom '2016-05-18 11:04:00' --dateto '2016-05-18 11:09:59' ")
-        click.echo("Example usage: lecli get events --lognick mynicknamedlog "
+        click.echo("Example usage: lecli get events --favorites mylogalias "
                    "-r 'last 3 hours'")
 
 
 @click.command()
 # nargs (-1) makes sure multiple log keys is supported
 @click.argument('logkeys', type=click.STRING, nargs=-1)
-@click.option('-n', '--lognick', type=click.STRING, default=None,
-              help='Nickname of log in config file')
-@click.option('-g', '--loggroup', type=click.STRING, default=None,
-              help='Name of log group defined in config file')
+@click.option('-c', '--favorites', type=click.STRING, default=None,
+              help='Alias of log in config file')
+@click.option('-g', '--logset', type=click.STRING, default=None,
+              help='Name of logset to be got from server')
 @click.option('-l', '--last', type=click.INT, default=1200,
               help='Time window from now to now-X in seconds over which events will be returned '
                    '(Defaults to 20 mins)')
@@ -109,7 +101,7 @@ def get_events(logkeys, lognick, loggroup, timefrom, timeto, datefrom, dateto, r
               help='Relative range to query until now (Examples: today, yesterday, '
                    'last x timeunit: last 2 hours, last 6 weeks etc.')
 @click.option('-s', '--saved-query', help='Saved query to run', type=click.UUID)
-def get_recent_events(logkeys, lognick, loggroup, last, relative_range, saved_query):
+def get_recent_events(logkeys, favorites, logset, last, relative_range, saved_query):
     """Get recent log events"""
     start_time = now = None
     if not relative_range:
@@ -118,30 +110,30 @@ def get_recent_events(logkeys, lognick, loggroup, last, relative_range, saved_qu
 
     success = api.query(log_keys=logkeys, query_string=api.ALL_EVENTS_QUERY,
                         time_from=start_time, time_to=now, relative_time_range=relative_range,
-                        lognick=lognick, loggroup=loggroup, saved_query_id=saved_query)
+                        favorites=favorites, logset=logset, saved_query_id=saved_query)
     if not success:
         click.echo(
             'Example usage: lecli get recentevents 12345678-aaaa-bbbb-1234-1234cb123456 -l 200')
-        click.echo('Example usage: lecli get recentevents -n mynicknamedlog -l 200')
-        click.echo('Example usage: lecli get recentevents -g myloggroup -l 200')
-        click.echo("Example usage: lecli get recentevents -g myloggroup -r 'last 50 mins'")
+        click.echo('Example usage: lecli get recentevents -c mylogalias -l 200')
+        click.echo('Example usage: lecli get recentevents -g mylogset -l 200')
+        click.echo("Example usage: lecli get recentevents -g mylogset -r 'last 50 mins'")
 
 
 @click.command()
 # nargs (-1) makes sure multiple log keys is supported
 @click.argument('logkeys', type=click.STRING, nargs=-1)
-@click.option('-n', '--lognick', type=click.STRING, default=None,
-              help='Nickname of log in config file')
-@click.option('-g', '--loggroup', type=click.STRING, default=None,
-              help='Name of log group defined in config file')
+@click.option('-c', '--favorites', type=click.STRING, default=None,
+              help='Alias of log in config file')
+@click.option('-g', '--logset', type=click.STRING, default=None,
+              help='Name of logset to be got from server')
 @click.option('-l', '--leql', type=click.STRING, default=None,
               help='LEQL query to filter')
 @click.option('-i', '--poll-interval', type=click.FLOAT, default=1.0,
               help='Request interval of live tail in seconds, default is 1.0 second.')
 @click.option('-s', '--saved-query', type=click.UUID, help='Saved query id to tail.')
-def tail_events(logkeys, lognick, loggroup, leql, poll_interval, saved_query):
+def tail_events(logkeys, favorites, logset, leql, poll_interval, saved_query):
     """Tail events of given logkey(s) with provided options"""
-    success = api.tail_logs(logkeys, leql, poll_interval, lognick, loggroup, saved_query)
+    success = api.tail_logs(logkeys, leql, poll_interval, favorites, logset, saved_query)
 
     if not success:
         click.echo("Example usage: lecli tail events 12345678-aaaa-bbbb-1234-1234cb123456")

--- a/tests/test_apiutils.py
+++ b/tests/test_apiutils.py
@@ -203,6 +203,18 @@ def test_get_invalid_named_group_key(capsys):
             assert 'was not found' in out
 
 
+@patch('ConfigParser.ConfigParser')
+def test_replace_loggroup_section(mocked_configparser_class):
+    loggroups_section = api_utils.LOGGROUPS_SECTION
+    config_parser_mock = mocked_configparser_class.return_value
+    config_parser_mock.add_section(loggroups_section)
+    with patch.object(api_utils.CONFIG, 'items',
+                       return_value=[('test-log-group-favs', ["test-log-key1", "test-log-key2"])]):
+        api_utils.replace_loggroup_section()
+        assert not api_utils.CONFIG.has_section(loggroups_section)
+        assert config_parser_mock.has_section('CLI_Favorites')
+
+
 @patch('lecli.api_utils.get_api_url')
 def test_generate_api_url(mocked_api_url):
     mocked_api_url.return_value = MOCK_API_URL

--- a/tests/test_apiutils.py
+++ b/tests/test_apiutils.py
@@ -176,52 +176,25 @@ def test_get_invalid_account_resource_id(capsys):
             assert 'is not of correct length' in out
 
 
-def test_get_valid_named_logkey():
-    with patch.object(ConfigParser.ConfigParser, 'items', return_value=[('test-logkey-nick',
-                                                                         ID_WITH_VALID_LENGTH)]):
-        logkey = api_utils.get_named_logkey('test-logkey-nick')
-        assert logkey == (ID_WITH_VALID_LENGTH,)
-
-
-def test_case_insensitivity_of_named_logkey():
-    with patch.object(ConfigParser.ConfigParser, 'items', return_value=[('test-logkey-nick',
-                                                                         ID_WITH_VALID_LENGTH)]):
-        logkey = api_utils.get_named_logkey('TEST-logkey-nick')
-        assert logkey == (ID_WITH_VALID_LENGTH,)
-
-
-def test_get_invalid_named_logkey(capsys):
-    with patch.object(ConfigParser.ConfigParser, 'items', return_value=[('test-logkey-nick',
-                                                                         ID_WITH_VALID_LENGTH)]):
-        with pytest.raises(SystemExit):
-            nick_to_query = 'test-logkey-nick_invalid'
-            logkey = api_utils.get_named_logkey(nick_to_query)
-            out, err = capsys.readouterr()
-
-            assert logkey is None
-            assert nick_to_query in out
-            assert 'was not found' in out
-
-
 def test_get_valid_named_group_key():
     with patch.object(ConfigParser.ConfigParser, 'items',
-                      return_value=[('test-log-group-nick', ID_WITH_VALID_LENGTH)]):
-        logkeys = api_utils.get_named_logkey_group('test-log-group-nick')
+                      return_value=[('test-log-group-favs', ID_WITH_VALID_LENGTH)]):
+        logkeys = api_utils.get_named_logkey_group('test-log-group-favs')
         assert logkeys == filter(None, ID_WITH_VALID_LENGTH.splitlines())
 
 
 def test_case_insensitivity_of_named_groups_key():
     with patch.object(ConfigParser.ConfigParser, 'items',
-                      return_value=[('test-log-group-nick', '')]):
-        logkeys = api_utils.get_named_logkey_group('TEST-log-group-nick')
+                      return_value=[('test-log-group-favs', '')]):
+        logkeys = api_utils.get_named_logkey_group('TEST-log-group-favs')
         assert logkeys == filter(None, ''.splitlines())
 
 
 def test_get_invalid_named_group_key(capsys):
     with patch.object(ConfigParser.ConfigParser, 'items',
-                      return_value=[('test-log-group-nick', ["test-log-key1", "test-log-key2"])]):
+                      return_value=[('test-log-group-favs', ["test-log-key1", "test-log-key2"])]):
         with pytest.raises(SystemExit):
-            nick_to_query = 'test-log-group-nick-invalid'
+            nick_to_query = 'test-log-group-favs-invalid'
             result = api_utils.get_named_logkey_group(nick_to_query)
             out, err = capsys.readouterr()
 

--- a/tests/test_apiutils.py
+++ b/tests/test_apiutils.py
@@ -1,11 +1,12 @@
 import ConfigParser
 import hmac
 import uuid
+import os
 
 import pytest
 from mock import patch, Mock
 
-from lecli import api_utils
+from lecli import api_utils, cli
 
 ID_WITH_VALID_LENGTH = str(uuid.uuid4())
 ID_WITH_INVALID_LENGTH = str(uuid.uuid4()) + 'invalid'
@@ -205,6 +206,12 @@ def test_get_invalid_named_group_key(capsys):
 
 @patch('ConfigParser.ConfigParser')
 def test_replace_loggroup_section(mocked_configparser_class):
+
+    config_dir = api_utils.user_config_dir(cli.lecli.__name__)
+    if not os.path.exists(api_utils.CONFIG_FILE_PATH):
+        if not os.path.exists(config_dir):
+            os.makedirs(config_dir)
+
     loggroups_section = api_utils.LOGGROUPS_SECTION
     config_parser_mock = mocked_configparser_class.return_value
     config_parser_mock.add_section(loggroups_section)
@@ -214,6 +221,11 @@ def test_replace_loggroup_section(mocked_configparser_class):
         assert not api_utils.CONFIG.has_section(loggroups_section)
         assert config_parser_mock.has_section('CLI_Favorites')
 
+    try:
+        os.remove(api_utils.CONFIG_FILE_PATH)
+        os.rmdir(config_dir)
+    except OSError:
+        pass
 
 @patch('lecli.api_utils.get_api_url')
 def test_generate_api_url(mocked_api_url):

--- a/tests/test_apiutils.py
+++ b/tests/test_apiutils.py
@@ -219,7 +219,7 @@ def test_replace_loggroup_section(mocked_configparser_class):
                        return_value=[('test-log-group-favs', ["test-log-key1", "test-log-key2"])]):
         api_utils.replace_loggroup_section()
         assert not api_utils.CONFIG.has_section(loggroups_section)
-        assert config_parser_mock.has_section('CLI_Favorites')
+        assert config_parser_mock.has_section(api_utils.CLI_FAVORITES_SECTION)
 
     try:
         os.remove(api_utils.CONFIG_FILE_PATH)

--- a/tests/test_queryapi.py
+++ b/tests/test_queryapi.py
@@ -349,10 +349,7 @@ def test_handle_response(capsys):
 def test_validate_query():
     # general query
     assert api.validate_query(query_string='foo', log_keys='bar', time_from=123) is True
-    assert api.validate_query(querynick='foo', log_keys='bar', time_from=123) is True
-    assert api.validate_query(querynick='foo', loggroup='bar', time_from=123) is True
-    assert api.validate_query(querynick='foo', lognick='bar', time_from=123) is True
-    assert api.validate_query(loggroup='foo', lognick='bar', time_from=123) is False
+    assert api.validate_query(logset='foo', favorites='bar', time_from=123) is False
     assert api.validate_query(foo='bar') is False
     assert api.validate_query(query_string='foo') is False
     assert api.validate_query(log_keys='foo') is False


### PR DESCRIPTION
@ilyabiryukov-r7 @pquinn-r7 
Howdy gents!
Looking for a review.
Thanks!

Commits on the work done that have been squashed:

- LOG-9749 Removal of query nicknames use
- LOG-9749 Introduce CLI Favorites, remove reference to Log Nicknames
- LOG-9749 Part 1 of removing log group, replacing with log set
- LOG-9749 Make CLI Favorites work with lists of log Ids in config
- LOG-9749 Add use of logsets ID in query and events requests